### PR TITLE
🐛 Made arrow functions the same color as normal functions

### DIFF
--- a/themes/codeSTACKr-theme-muted.json
+++ b/themes/codeSTACKr-theme-muted.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "Identifier",
-      "scope": "variable, support.variable, support.class, support.constant, meta.definition.variable entity.name.function",
+      "scope": "variable, support.variable, support.class, support.constant, meta.definition.variable, entity.name.function",
       "settings": {
         "foreground": "#a8a2ff"
       }
@@ -126,7 +126,7 @@
     },
     {
       "name": "Function definition",
-      "scope": "meta.function entity.name.function",
+      "scope": "meta.function, entity.name.function",
       "settings": {
         "foreground": "#bae0f8"
       }

--- a/themes/codeSTACKr-theme.json
+++ b/themes/codeSTACKr-theme.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "Identifier",
-      "scope": "variable, support.variable, support.class, support.constant, meta.definition.variable entity.name.function",
+      "scope": "variable, support.variable, support.class, support.constant, meta.definition.variable, entity.name.function",
       "settings": {
         "foreground": "#746aff"
       }
@@ -126,7 +126,7 @@
     },
     {
       "name": "Function definition",
-      "scope": "meta.function entity.name.function",
+      "scope": "meta.function, entity.name.function",
       "settings": {
         "foreground": "#5eb7ee"
       }


### PR DESCRIPTION
Fixes #6 .
## Before:
![image](https://user-images.githubusercontent.com/51731966/102757145-e15c2580-4396-11eb-9b30-fe1f7eee2f8b.png)
## After:
![image](https://user-images.githubusercontent.com/51731966/102757158-e6b97000-4396-11eb-9539-8d615b197236.png)


@codeSTACKr What do you think about it? A missing comma also caused this issue