### PR TITLE
Some improvements to the theme

### DIFF
--- a/themes/codeSTACKr-theme-muted.json
+++ b/themes/codeSTACKr-theme-muted.json
@@ -45,6 +45,13 @@
       }
     },
     {
+      "name": "Constant",
+      "scope": "variable.other.constant",
+      "settings": {
+        "foreground": "#ffa2b6"
+      }
+    },
+    {
       "name": "Keyword",
       "scope": "keyword, modifier, variable.language.this, support.type.object, constant.language",
       "settings": {

--- a/themes/codeSTACKr-theme-muted.json
+++ b/themes/codeSTACKr-theme-muted.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "Storage",
-      "scope": "storage.type, storage.modifier",
+      "scope": "storage.type, storage.modifier, keyword.operator.expression",
       "settings": {
         "foreground": "#ffb59a"
       }
@@ -84,14 +84,14 @@
       "name": "Type",
       "scope": "support.type",
       "settings": {
-        "foreground": "#bae0f8"
+        "foreground": "#ffca75"
       }
     },
     {
       "name": "Type",
       "scope": "entity.name.type, entity.other.inherited-class",
       "settings": {
-        "foreground": "#bae0f8"
+        "foreground": "#ffca75"
       }
     },
     {
@@ -106,7 +106,7 @@
       "name": "Class",
       "scope": "entity.name.type.class",
       "settings": {
-        "foreground": "#bae0f8",
+        "foreground": "#ffca75",
         "fontStyle": "underline"
       }
     },

--- a/themes/codeSTACKr-theme.json
+++ b/themes/codeSTACKr-theme.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "Storage",
-      "scope": "storage.type, storage.modifier",
+      "scope": "storage.type, storage.modifier, keyword.operator.expression",
       "settings": {
         "foreground": "#FF652F"
       }

--- a/themes/codeSTACKr-theme.json
+++ b/themes/codeSTACKr-theme.json
@@ -45,6 +45,13 @@
       }
     },
     {
+      "name": "Constant",
+      "scope": "variable.other.constant",
+      "settings": {
+        "foreground": "#ff5177"
+      }
+    },
+    {
       "name": "Keyword",
       "scope": "keyword, modifier, variable.language.this, support.type.object, constant.language",
       "settings": {

--- a/themes/codeSTACKr-theme.json
+++ b/themes/codeSTACKr-theme.json
@@ -84,14 +84,14 @@
       "name": "Type",
       "scope": "support.type",
       "settings": {
-        "foreground": "#5eb7ee"
+        "foreground": "#ff9d00"
       }
     },
     {
       "name": "Type",
       "scope": "entity.name.type, entity.other.inherited-class",
       "settings": {
-        "foreground": "#5eb7ee"
+        "foreground": "#ff9d00"
       }
     },
     {
@@ -106,7 +106,7 @@
       "name": "Class",
       "scope": "entity.name.type.class",
       "settings": {
-        "foreground": "#5eb7ee",
+        "foreground": "#ff9d00",
         "fontStyle": "underline"
       }
     },


### PR DESCRIPTION
> ## Before
![image](https://user-images.githubusercontent.com/51731966/105187523-e3adcd00-5b58-11eb-8023-4ee3529af461.png)
---
![image](https://user-images.githubusercontent.com/51731966/105187603-f7593380-5b58-11eb-82c4-43230ceb70fc.png)

> ## After
![image](https://user-images.githubusercontent.com/51731966/105187360-b6611f00-5b58-11eb-87a7-61293acca878.png)
---
![image](https://user-images.githubusercontent.com/51731966/105187389-be20c380-5b58-11eb-861b-f05a02a4123c.png)

I added different color for the types for TypeScript and added a different color for `typeof` operator as it was very confusing with the `if else` and `return`. And added a different color for `const` constants